### PR TITLE
feat: 优化极简播放模式

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
             android:name="com.ryanheise.audioservice.AudioService"
             android:foregroundServiceType="mediaPlayback"
             android:exported="true"
+            android:stopWithTask="true"
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="android.media.browse.MediaBrowserService" />

--- a/lib/features/minimal/presentation/minimal_screen.dart
+++ b/lib/features/minimal/presentation/minimal_screen.dart
@@ -7,19 +7,32 @@ import 'package:go_router/go_router.dart';
 import '../../../core/api/bili_dio.dart';
 import '../../../core/router/app_router.dart';
 import '../../../core/utils/logger.dart';
+import '../../../main.dart';
 import '../../auth/application/auth_notifier.dart';
 import '../../player/application/player_notifier.dart';
 import '../../player/domain/models/audio_track.dart';
+import '../../player/domain/models/play_mode.dart';
 import '../../playlist/data/playlist_repository_impl.dart';
-import '../../search_and_parse/data/parse_repository.dart';
 import '../../search_and_parse/data/parse_repository_impl.dart';
 import '../../settings/application/settings_notifier.dart';
+import 'widgets/minimal_background.dart';
+import 'widgets/song_info_panel.dart';
 
 /// 极简模式页面（内部代号：给我一首歌）。
 ///
-/// 全黑背景，自动随机抽歌并播放。
+/// 毛玻璃封面背景 + 呼吸动效，自动将歌单塞入播放队列并以 Shuffle 模式连播。
 /// 双击屏幕退出极简模式，回到原版主页。
-/// 退到后台时自动停止播放。
+///
+/// 生命周期策略（解决 Flutter 无法区分锁屏 vs 切后台的痛点）：
+/// - 锁屏 / 切后台 / 回到前台 → **完全不干预播放**
+///   （audio_service 前台服务维持后台音频会话，锁屏继续播放）
+/// - 划掉应用 (`detached`) → 完整停止播放 + 销毁 AudioService 前台服务
+///
+/// 为什么不在 paused/resumed 中做任何事：
+/// Flutter 的 AppLifecycleState.paused 在锁屏和切后台时**都**会触发，
+/// 无法可靠区分。若在 paused 中暂停，锁屏听歌会中断；
+/// 若在 resumed 中切歌，解锁后会误切歌。两者都严重影响体验。
+/// 因此采用"完全不干预"策略，优先保证锁屏连续播放。
 class MinimalScreen extends ConsumerStatefulWidget {
   const MinimalScreen({super.key});
 
@@ -29,17 +42,15 @@ class MinimalScreen extends ConsumerStatefulWidget {
 
 class _MinimalScreenState extends ConsumerState<MinimalScreen>
     with WidgetsBindingObserver {
-  String _statusText = '🎵 正在为你播放...';
   bool _isLoading = true;
+  String? _errorMessage;
 
   @override
   void initState() {
     super.initState();
-    // 监听 App 生命周期，用于即完即走
     WidgetsBinding.instance.addObserver(this);
-    // 进入页面后触发异步抽歌
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _pickAndPlay();
+      _initQueue();
     });
   }
 
@@ -49,173 +60,189 @@ class _MinimalScreenState extends ConsumerState<MinimalScreen>
     super.dispose();
   }
 
-  /// 监听生命周期：退到后台或划掉应用时停止播放
+  /// 生命周期监听：仅处理 `detached`（应用被划掉）。
+  ///
+  /// paused / hidden / resumed 全部不做任何播放干预，原因：
+  /// - Flutter 的 `paused` 在锁屏和切后台时都会触发，无法区分
+  /// - 若在 `paused` 中暂停 → 锁屏时音乐中断（Bug #2）
+  /// - 若在 `resumed` 中切歌 → 解锁时误切歌（Bug #2）
+  /// - audio_service 前台服务天然维持后台/锁屏音频会话
+  ///
+  /// detached 时完整停止：先暂停 media_kit 播放器，再销毁 AudioService
+  /// 前台服务（移除通知 + 释放 WakeLock），确保无进程残留。
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.paused ||
-        state == AppLifecycleState.detached) {
-      _stopPlayback();
-    }
-  }
+    if (state != AppLifecycleState.detached) return;
 
-  /// 停止播放
-  void _stopPlayback() {
+    // ── 应用被划掉：完整停止播放 + 销毁前台服务 ──
     try {
       ref.read(playerNotifierProvider.notifier).pause();
+      // 通过 audioHandlerProvider 调用 stop()，销毁前台服务（移除通知栏、释放 WakeLock）
+      // 配合 AndroidManifest 的 stopWithTask="true" 双保险
+      ref.read(audioHandlerProvider).stop();
+      AppLogger.info('App detached: 已停止播放并销毁音频服务', tag: 'Minimal');
     } catch (e) {
-      AppLogger.error('停止播放失败', tag: 'Minimal', error: e);
+      AppLogger.error('detached 清理失败', tag: 'Minimal', error: e);
     }
   }
 
-  /// 核心逻辑：抽歌并播放
-  Future<void> _pickAndPlay() async {
-    final parseRepo = ParseRepositoryImpl(biliDio: BiliDio());
-
-    try {
-      final track = await _resolveRandomTrack(parseRepo);
-      if (!mounted) return;
-
-      // 获取音频流 URL
-      final streamInfo = await parseRepo.getAudioStream(
-        track.bvid,
-        track.cid,
-        quality: _preferredQuality,
-      );
-      if (!mounted) return;
-
-      final playableTrack = track.copyWith(
-        streamUrl: streamInfo.url,
-        quality: streamInfo.quality,
-      );
-
-      // 调用全局播放器播放
-      await ref.read(playerNotifierProvider.notifier).playTrack(playableTrack);
-      if (!mounted) return;
-
-      setState(() {
-        _statusText = '🎵 ${playableTrack.title}\n${playableTrack.artist}';
-        _isLoading = false;
-      });
-    } catch (e, st) {
-      AppLogger.error('极简模式抽歌失败', tag: 'Minimal', error: e, stackTrace: st);
-      if (!mounted) return;
-      setState(() {
-        _statusText = '😢 加载失败，双击退出';
-        _isLoading = false;
-      });
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('网络请求失败，请检查网络后重试')),
-      );
-    }
-  }
-
-  /// 获取用户偏好音质
-  int? get _preferredQuality {
-    final q = ref.read(settingsNotifierProvider).preferredQuality;
-    return q == 0 ? null : q;
-  }
-
-  /// 根据优先级获取随机曲目的 AudioTrack（不含 streamUrl）
+  /// 核心初始化：加载歌单 → 塞入完整队列 → 开启 Shuffle 模式 → 播放。
   ///
-  /// 优先级：本地歌单 > 搜索音乐热门
-  Future<AudioTrack> _resolveRandomTrack(ParseRepository parseRepo) async {
-    final random = Random();
+  /// 优先级：本地歌单 → B站搜索兜底。
+  /// 所有播放均委托给 [PlayerNotifier] 原生管线
+  /// （自动查本地缓存、WBI 签名 API、Referer Header）。
+  Future<void> _initQueue() async {
+    try {
+      final random = Random();
+      final playerNotifier = ref.read(playerNotifierProvider.notifier);
 
-    // ── 优先级 1：从设置中指定的本地歌单随机抽歌 ──
-    final minimalPlaylistId = await ref
-        .read(settingsNotifierProvider.notifier)
-        .getMinimalPlaylistId();
-    if (minimalPlaylistId != null && minimalPlaylistId > 0) {
-      try {
+      // ── 强制开启 Shuffle 模式，确保连播时随机 ──
+      playerNotifier.setMode(PlayMode.shuffle);
+
+      // ── 优先级 1：本地歌单 → playSongFromPlaylist（整队列） ──
+      final playlistId = await ref
+          .read(settingsNotifierProvider.notifier)
+          .getMinimalPlaylistId();
+      if (playlistId != null && playlistId > 0) {
         final db = ref.read(databaseProvider);
         final playlistRepo = PlaylistRepositoryImpl(db: db);
-        final songs = await playlistRepo.getSongsInPlaylist(minimalPlaylistId);
+        final songs = await playlistRepo.getSongsInPlaylist(playlistId);
         if (songs.isNotEmpty) {
-          final song = songs[random.nextInt(songs.length)];
-          return AudioTrack(
-            songId: song.id,
-            bvid: song.bvid,
-            cid: song.cid,
-            title: song.displayTitle,
-            artist: song.displayArtist,
-            coverUrl: song.coverUrl,
-            localPath: song.localPath,
-            duration: Duration(seconds: song.duration),
-            quality: song.audioQuality,
+          // 随机选一首作为起点，整个歌单作为队列
+          final startSong = songs[random.nextInt(songs.length)];
+          await playerNotifier.playSongFromPlaylist(
+            song: startSong,
+            songs: songs,
+            playlistId: playlistId,
           );
+          if (!mounted) return;
+          setState(() => _isLoading = false);
+          return;
         }
-      } catch (e) {
-        AppLogger.warning('从本地歌单获取歌曲失败，回退到搜索', tag: 'Minimal');
       }
+
+      // ── 优先级 2：B站搜索兜底 → playTrackList（整列表） ──
+      final parseRepo = ParseRepositoryImpl(biliDio: BiliDio());
+      final searchResult = await parseRepo.searchVideos('音乐');
+      if (searchResult.results.isEmpty) {
+        throw Exception('未找到任何音乐视频');
+      }
+
+      // 将搜索结果全部转为 AudioTrack 队列（streamUrl 留空，由 next 时按需解析）
+      final tracks = <AudioTrack>[];
+      for (final video in searchResult.results) {
+        try {
+          final info = await parseRepo.getVideoInfo(video.bvid);
+          if (info.pages.isEmpty) continue;
+          final page = info.pages.first;
+          tracks.add(AudioTrack(
+            songId: 0,
+            bvid: info.bvid,
+            cid: page.cid,
+            title: info.title,
+            artist: info.owner,
+            coverUrl: info.coverUrl,
+            duration: Duration(seconds: page.duration),
+          ));
+        } catch (e) {
+          // 单个视频解析失败不阻塞整体
+          AppLogger.warning('跳过视频 ${video.bvid}', tag: 'Minimal');
+        }
+      }
+
+      if (tracks.isEmpty) throw Exception('未找到可播放的音乐视频');
+
+      // 随机起点
+      final startIndex = random.nextInt(tracks.length);
+      await playerNotifier.playTrackList(tracks, startIndex);
+      if (!mounted) return;
+      setState(() => _isLoading = false);
+    } catch (e, st) {
+      AppLogger.error('极简模式初始化失败', tag: 'Minimal', error: e, stackTrace: st);
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+        _errorMessage = '加载失败，双击退出重试';
+      });
     }
-
-    // ── 优先级 2：搜索 B站 音乐区热门视频 ──
-    final searchResult = await parseRepo.searchVideos('音乐');
-    final videos = searchResult.results;
-    if (videos.isEmpty) {
-      throw Exception('未找到任何音乐视频');
-    }
-
-    // 随机选一个视频
-    final video = videos[random.nextInt(videos.length)];
-
-    // 需要通过 getVideoInfo 获取 cid（搜索结果不包含 pages/cid）
-    final videoInfo = await parseRepo.getVideoInfo(video.bvid);
-    if (videoInfo.pages.isEmpty) {
-      throw Exception('视频 ${video.bvid} 没有可用分P');
-    }
-    final page = videoInfo.pages.first;
-
-    return AudioTrack(
-      songId: 0,
-      bvid: videoInfo.bvid,
-      cid: page.cid,
-      title: videoInfo.title,
-      artist: videoInfo.owner,
-      coverUrl: videoInfo.coverUrl,
-      duration: Duration(seconds: page.duration),
-    );
   }
 
-  /// 双击退出极简模式，回到原版主页
+  /// 双击退出极简模式
   void _exitMinimalMode() {
     context.go(AppRoutes.home);
   }
 
   @override
   Widget build(BuildContext context) {
+    // ★ watch playerState：1) 保持 provider 存活  2) 自动刷新 UI（切歌/封面）
+    final playerState = ref.watch(playerNotifierProvider);
+    final currentTrack = playerState.currentTrack;
+
     return Scaffold(
       backgroundColor: Colors.black,
       body: GestureDetector(
         onDoubleTap: _exitMinimalMode,
         behavior: HitTestBehavior.opaque,
-        child: SizedBox.expand(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              if (_isLoading)
-                const CircularProgressIndicator(color: Colors.white54),
-              const SizedBox(height: 24),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 32),
-                child: Text(
-                  _statusText,
-                  textAlign: TextAlign.center,
-                  style: const TextStyle(
-                    color: Colors.white70,
-                    fontSize: 20,
-                    height: 1.6,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            // ── 毛玻璃呼吸背景 ──
+            MinimalBackground(coverUrl: currentTrack?.coverUrl),
+
+            // ── 前景内容 ──
+            SafeArea(
+              child: Column(
+                children: [
+                  // ── 顶部操作栏（隐蔽的退出按钮） ──
+                  Align(
+                    alignment: Alignment.topRight,
+                    child: Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: IconButton(
+                        onPressed: _exitMinimalMode,
+                        icon: Icon(
+                          Icons.close_rounded,
+                          color: Colors.white.withValues(alpha: 0.3),
+                          size: 24,
+                        ),
+                        tooltip: '退出极简模式',
+                      ),
+                    ),
                   ),
-                ),
+
+                  // ── 居中歌曲信息面板 ──
+                  Expanded(
+                    child: Center(
+                      child: _errorMessage != null
+                          ? Text(
+                              _errorMessage!,
+                              style: const TextStyle(
+                                color: Colors.white54,
+                                fontSize: 16,
+                              ),
+                            )
+                          : SongInfoPanel(
+                              track: currentTrack,
+                              isLoading: _isLoading,
+                            ),
+                    ),
+                  ),
+
+                  // ── 底部提示 ──
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 32),
+                    child: Text(
+                      '双击屏幕退出',
+                      style: TextStyle(
+                        color: Colors.white.withValues(alpha: 0.2),
+                        fontSize: 12,
+                      ),
+                    ),
+                  ),
+                ],
               ),
-              const SizedBox(height: 48),
-              if (!_isLoading)
-                const Text(
-                  '双击屏幕退出极简模式',
-                  style: TextStyle(color: Colors.white24, fontSize: 13),
-                ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/minimal/presentation/widgets/minimal_background.dart
+++ b/lib/features/minimal/presentation/widgets/minimal_background.dart
@@ -1,0 +1,125 @@
+import 'dart:ui';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+/// 极简模式的毛玻璃呼吸背景。
+///
+/// 取当前播放歌曲的封面图进行高斯模糊，并叠加一层缓慢脉动的
+/// 缩放 + 透明度呼吸动画，营造沉浸式氛围。
+class MinimalBackground extends StatefulWidget {
+  /// 封面图 URL，为 null 时显示纯渐变色背景。
+  final String? coverUrl;
+
+  const MinimalBackground({super.key, this.coverUrl});
+
+  @override
+  State<MinimalBackground> createState() => _MinimalBackgroundState();
+}
+
+class _MinimalBackgroundState extends State<MinimalBackground>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _breathController;
+  late final Animation<double> _scaleAnimation;
+  late final Animation<double> _opacityAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    // 呼吸周期 6 秒，永久循环
+    _breathController = AnimationController(
+      vsync: this,
+      duration: const Duration(seconds: 6),
+    )..repeat(reverse: true);
+
+    // 缩放幅度 1.0 → 1.12，平滑的正弦曲线
+    _scaleAnimation = Tween<double>(begin: 1.0, end: 1.12).animate(
+      CurvedAnimation(parent: _breathController, curve: Curves.easeInOut),
+    );
+
+    // 透明度微弱呼吸 0.6 → 0.85
+    _opacityAnimation = Tween<double>(begin: 0.6, end: 0.85).animate(
+      CurvedAnimation(parent: _breathController, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _breathController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _breathController,
+      builder: (context, child) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            // ── 底层：封面图或渐变色 ──
+            Opacity(
+              opacity: _opacityAnimation.value,
+              child: Transform.scale(
+                scale: _scaleAnimation.value,
+                child: _buildBackground(),
+              ),
+            ),
+
+            // ── 高斯模糊层 ──
+            BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 60, sigmaY: 60),
+              child: const SizedBox.expand(),
+            ),
+
+            // ── 暗色叠加层，保证前景文字可读 ──
+            Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.4),
+                    Colors.black.withValues(alpha: 0.7),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  /// 根据是否有封面 URL 构建背景图层。
+  Widget _buildBackground() {
+    final url = widget.coverUrl;
+    if (url != null && url.isNotEmpty) {
+      return CachedNetworkImage(
+        imageUrl: url,
+        fit: BoxFit.cover,
+        // 加载中和失败时回退到渐变色
+        placeholder: (_, __) => _gradientFallback(),
+        errorWidget: (_, __, ___) => _gradientFallback(),
+      );
+    }
+    return _gradientFallback();
+  }
+
+  /// 无封面时的默认渐变背景。
+  Widget _gradientFallback() {
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            Color(0xFF1A1A2E),
+            Color(0xFF16213E),
+            Color(0xFF0F3460),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/minimal/presentation/widgets/song_info_panel.dart
+++ b/lib/features/minimal/presentation/widgets/song_info_panel.dart
@@ -1,0 +1,177 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../../player/domain/models/audio_track.dart';
+
+/// 极简模式的歌曲信息面板。
+///
+/// 居中展示封面、歌名、歌手，切歌时通过 [AnimatedSwitcher] 自动渐变过渡。
+class SongInfoPanel extends StatelessWidget {
+  /// 当前播放的曲目，为 null 时显示占位。
+  final AudioTrack? track;
+
+  /// 是否正在加载中。
+  final bool isLoading;
+
+  const SongInfoPanel({
+    super.key,
+    required this.track,
+    this.isLoading = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 600),
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      child: _buildContent(context),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    if (isLoading) {
+      return const _LoadingPlaceholder(key: ValueKey('loading'));
+    }
+
+    final currentTrack = track;
+    if (currentTrack == null) {
+      return const _LoadingPlaceholder(key: ValueKey('empty'));
+    }
+
+    // 以 bvid+cid 作为 key，确保切歌时触发 AnimatedSwitcher 动画
+    return Column(
+      key: ValueKey('${currentTrack.bvid}_${currentTrack.cid}'),
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        // ── 封面图 ──
+        _CoverArt(coverUrl: currentTrack.coverUrl),
+        const SizedBox(height: 32),
+
+        // ── 歌曲名 ──
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 40),
+          child: Text(
+            currentTrack.title,
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 22,
+              fontWeight: FontWeight.w600,
+              height: 1.4,
+              letterSpacing: 0.5,
+            ),
+          ),
+        ),
+        const SizedBox(height: 10),
+
+        // ── 歌手名 ──
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 48),
+          child: Text(
+            currentTrack.artist,
+            textAlign: TextAlign.center,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: Colors.white.withValues(alpha: 0.7),
+              fontSize: 15,
+              fontWeight: FontWeight.w400,
+              letterSpacing: 0.3,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// 封面图组件：圆角带阴影。
+class _CoverArt extends StatelessWidget {
+  final String? coverUrl;
+
+  const _CoverArt({required this.coverUrl});
+
+  @override
+  Widget build(BuildContext context) {
+    const double size = 220;
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.4),
+            blurRadius: 30,
+            offset: const Offset(0, 10),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(20),
+        child: _buildImage(),
+      ),
+    );
+  }
+
+  Widget _buildImage() {
+    final url = coverUrl;
+    if (url != null && url.isNotEmpty) {
+      return CachedNetworkImage(
+        imageUrl: url,
+        fit: BoxFit.cover,
+        placeholder: (_, __) => _placeholder(),
+        errorWidget: (_, __, ___) => _placeholder(),
+      );
+    }
+    return _placeholder();
+  }
+
+  Widget _placeholder() {
+    return Container(
+      color: const Color(0xFF2A2A3E),
+      child: const Center(
+        child: Icon(
+          Icons.music_note_rounded,
+          color: Colors.white38,
+          size: 64,
+        ),
+      ),
+    );
+  }
+}
+
+/// 加载状态占位。
+class _LoadingPlaceholder extends StatelessWidget {
+  const _LoadingPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        SizedBox(
+          width: 48,
+          height: 48,
+          child: CircularProgressIndicator(
+            color: Colors.white38,
+            strokeWidth: 2.5,
+          ),
+        ),
+        SizedBox(height: 24),
+        Text(
+          '正在为你挑选音乐…',
+          style: TextStyle(
+            color: Colors.white54,
+            fontSize: 16,
+            letterSpacing: 0.3,
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## 📖 概述

新增「极简模式」功能（内部代号：**给我一首歌**）。用户在设置中开启后，下次启动 App 将直接进入极简播放界面——全屏毛玻璃动效背景、自动从指定歌单随机抽歌、Shuffle 连播，打造沉浸式盲盒听歌体验。双击屏幕即可退出，回到原版主页。

## ✨ 功能亮点

- **一键开启：** 设置页新增极简模式开关 + 本地歌单选择器（不指定则回退到 B站搜索）
- **队列连播：** 整个歌单作为播放队列塞入 `PlayerNotifier`，开启 `PlayMode.shuffle`，利用原有的 `_onTrackCompleted()` → `next()` 自动续播，无需定时器
- **动态 UI：** 歌曲封面高斯模糊背景 + 6s 呼吸缩放动画 + `AnimatedSwitcher` 切歌过渡
- **精细化生命周期：**
  - 锁屏 → 音乐继续（不干预，`audio_service` 前台服务维持会话）
  - 切后台 → 音乐继续（同上，无法可靠区分锁屏与切后台，优先保障锁屏体验）
  - 划掉应用 → `pause()` + `audioHandler.stop()` + `stopWithTask="true"` 双保险，彻底释放资源

## 🏗️ 工程质量：最小侵入原则

本 PR 严格遵循 **Minimal Viable Changes** 原则，所有新功能像插件一样挂载，原有架构零破坏：

| 维度 | 说明 |
|------|------|
| **新增文件（4 个）** | `minimal_screen.dart`、`minimal_background.dart`、`song_info_panel.dart`、`minimal_mode_section.dart` |
| **原有文件改动** | `main.dart` +7 行、`app_router.dart` +15 行、`settings_notifier.dart` +34 行、`settings_screen.dart` +3 行 |
| **绝不触碰** | `PlayerNotifier` / `PlayerRepositoryImpl` / `BusicAudioHandler` / `ParseRepositoryImpl` 等核心类的内部逻辑 |
| **状态管理** | 100% 复用 Riverpod，未引入任何新依赖 |
| **播放管线** | 全部委托 `playSongFromPlaylist()` / `playTrackList()` 原生方法 |

## 📦 附带修复

- **Android 构建：** 升级 AGP 8.9.1 / Kotlin 2.1.0 / Gradle 8.11.1（`androidx.browser:1.9.0` 要求 AGP ≥ 8.9.1）
- **AudioService 残留：** AndroidManifest 的 `<service>` 增加 `android:stopWithTask="true"`，修复划掉 App 后音频服务不停止的问题

## ✅ 检查清单

- [x] `dart format .` — 通过
- [x] `flutter analyze --no-fatal-infos` — 0 error / 0 warning
- [x] `flutter test` — 无新增失败
- [x] Release APK 构建成功（90.2MB）
- [x] 真机验证：队列连播 ✓ | 锁屏继续 ✓ | 划掉销毁 ✓